### PR TITLE
The github ribbon was overlapping the naviation when viewed in a small br

### DIFF
--- a/pygments/what-is-a-model/index.html
+++ b/pygments/what-is-a-model/index.html
@@ -33,6 +33,7 @@
             margin-left: 40px;
             padding-top: 10px;
             padding-bottom: 10px;
+            position: relative;
         }
         .menu a {
             margin-right: 10px;


### PR DESCRIPTION
The github ribbon was overlapping the naviation when viewed in a small browser window. Fixed :) 
