### PR TITLE
fixed typo in organizing-backbone-using-modules index.html

### DIFF
--- a/_site/organizing-backbone-using-modules/index.html
+++ b/_site/organizing-backbone-using-modules/index.html
@@ -319,7 +319,7 @@ We should setup any useful containers that might be used by our Backbone views.<
       <span class="s1">&#39;/users&#39;</span><span class="o">:</span> <span class="s1">&#39;showUsers&#39;</span><span class="p">,</span>
 
       <span class="c1">// Default</span>
-      <span class="s1">&#39;*actions&#39;: &quot;defaultAction&#39;</span>
+      <span class="s1">&#39;*actions&#39;: &#39;defaultAction&#39;</span>
     <span class="p">},</span>
     <span class="nx">showProjects</span><span class="o">:</span> <span class="kd">function</span><span class="p">(){</span>
       <span class="c1">// Call render on the module we loaded in via the dependency array</span>

--- a/_site/organizing-backbone-using-modules/index.html
+++ b/_site/organizing-backbone-using-modules/index.html
@@ -319,7 +319,7 @@ We should setup any useful containers that might be used by our Backbone views.<
       <span class="s1">&#39;/users&#39;</span><span class="o">:</span> <span class="s1">&#39;showUsers&#39;</span><span class="p">,</span>
 
       <span class="c1">// Default</span>
-      <span class="s1">&#39;*actions&quot;: &quot;defaultAction&#39;</span>
+      <span class="s1">&#39;*actions&#39;: &quot;defaultAction&#39;</span>
     <span class="p">},</span>
     <span class="nx">showProjects</span><span class="o">:</span> <span class="kd">function</span><span class="p">(){</span>
       <span class="c1">// Call render on the module we loaded in via the dependency array</span>


### PR DESCRIPTION
Fixed mismatched quotes type in router.js file example.
