### PR TITLE
Fix code highlighting on _site/organizing-backbone-using-modules/index.html

### DIFF
--- a/_site/organizing-backbone-using-modules/index.html
+++ b/_site/organizing-backbone-using-modules/index.html
@@ -366,7 +366,7 @@ We should setup any useful containers that might be used by our Backbone views.<
       <span class="s1">&#39;/users&#39;</span><span class="o">:</span> <span class="s1">&#39;showUsers&#39;</span><span class="p">,</span>
 
       <span class="c1">// Default</span>
-      <span class="s1">&#39;*actions&quot;: &#39;</span><span class="nx">defaultAction</span><span class="s1">&#39;</span>
+      <span class="s1">&#39;*actions&#39;: &#39;</span><span class="nx">defaultAction</span><span class="s1">&#39;</span>
 <span class="s1">    },</span>
 <span class="s1">    showProjects: function(){</span>
 <span class="s1">      // Call render on the module we loaded in via the dependency array</span>


### PR DESCRIPTION
Replace double quote with single quote.
