### PR TITLE
Fix for footer only showing up when entering default page initially.

### DIFF
--- a/examples/modular-backbone/js/router.js
+++ b/examples/modular-backbone/js/router.js
@@ -44,13 +44,13 @@ define([
        // We have no matching route, lets display the home page 
         var homeView = new HomeView();
         homeView.render();
-
-         // unlike the above, we don't call render on this view
-        // as it will handle the render call internally after it
-        // loads data 
-        var footerView = new FooterView();
-
     });
+
+    // Unlike the above, we don't call render on this view as it will handle
+    // the render call internally after it loads data. Further more we load it
+    // outside of an on-route function to have it loaded no matter which page is
+    // loaded initially.
+    var footerView = new FooterView();
 
     Backbone.history.start();
   };


### PR DESCRIPTION
Footer also should load when entering e.g. [modular-backbone/#/projects](http://backbonetutorials.com/examples/modular-backbone/#/projects) initially -  shouldn't it?
