### PR TITLE
Update event binding and force validation on set

### DIFF
--- a/_posts/2011-01-29-what-is-a-model.md
+++ b/_posts/2011-01-29-what-is-a-model.md
@@ -294,19 +294,21 @@ _Validate data before you set or save it_
         },
         initialize: function(){
             alert("Welcome to this world");
-            this.bind("error", function(model, error){
+			// The invalid event is used to handle validation errors on the client-side
+            this.bind("invalid", function(model, error){
                 // We have received an error, log it, alert it or forget it :)
                 alert( error );
             });
         }
     });
     
+	// By default, Backbone will only validate models on save, not set. We can override that by passing in validate: true
     var person = new Person;
-    person.set({ name: "Mary Poppins", age: -1 }); 
+    person.set({ name: "Mary Poppins", age: -1 }, {validate: true}); 
     // Will trigger an alert outputting the error
     
     var person = new Person;
-    person.set({ name: "Dr Manhatten", age: -1 });
+    person.set({ name: "Dr Manhatten", age: -1 }, {validate: true});
     // God have mercy on our souls
     
 {% endhighlight %}


### PR DESCRIPTION
This changes the event binding to `invalid` from `error` as that is now the event used for this. Also forces validation on `set()` by passing in `{validate: true}`
