### PR TITLE
Fix markdown - escape asterisk in "*splat".

### DIFF
--- a/_posts/2011-01-27-what-is-a-router.md
+++ b/_posts/2011-01-27-what-is-a-router.md
@@ -78,7 +78,7 @@ _Notice the change in the url_
 
 ## Dynamic Routing Cont. ":params" and "*splats"
 
-Backbone uses two styles of variables when implementing routes.   First there are ":params" which match any URL components between slashes.  Then there are "*splats" which match any number of URL components.   Note that due to the nature of a "*splat" it will always be the last variable in your URL as it will match any and all components.
+Backbone uses two styles of variables when implementing routes.   First there are ":params" which match any URL components between slashes.  Then there are "\*splats" which match any number of URL components.   Note that due to the nature of a "*splat" it will always be the last variable in your URL as it will match any and all components.
 
 Any "*splats" or ":params" in route definitions are passed as arguments (in respective order) to the associated function.  A route defined as "/:route/:action" will pass 2 variables (“route” and “action”) to the callback function.     (If this is confusing please post a comment and I will try articulate it better)
 


### PR DESCRIPTION
Displaying as italicized, rather than as "*splat".
