### PR TITLE
Typo: Added 'is' to "if it not defined"

### DIFF
--- a/_posts/2011-01-28-what-is-a-view.md
+++ b/_posts/2011-01-28-what-is-a-view.md
@@ -27,7 +27,7 @@ For the purposes of this demonstration, we will be implementing a search box. [A
 
 ## The "el" property
 
-The "el" property references the DOM object created in the browser. Every Backbone.js view has an "el" property, and if it not defined, Backbone.js will construct its own, which is an empty div element.
+The "el" property references the DOM object created in the browser. Every Backbone.js view has an "el" property, and if it is not defined, Backbone.js will construct its own, which is an empty div element.
 
 Let us set our view's "el" property to div#search_container, effectively making Backbone.View the owner of the DOM element.
 


### PR DESCRIPTION
Added 'is' to the following sentence: "Every Backbone.js view has an "el" property, and if it is not defined, Backbone.js will construct its own, which is an empty div element."

![image](https://cloud.githubusercontent.com/assets/7017045/5586318/a858945c-907e-11e4-8e43-e1ec731daac0.png)
