### PR TITLE
Updated underscore links to point to underscorejs.org

### DIFF
--- a/_posts/2011-01-28-what-is-a-view.md
+++ b/_posts/2011-01-28-what-is-a-view.md
@@ -7,7 +7,7 @@ posturl: http://backbonetutorials.com/what-is-a-view
 
 # What is a view?
 
-Backbone views are used to reflect what your applications' data models look like. They are also used to listen to events and react accordingly. This tutorial will not be addressing how to bind models and collections to views but will focus on view functionality and how to use views with a JavaScript templating library, specifically [Underscore.js's _.template](http://documentcloud.github.com/underscore/#template).
+Backbone views are used to reflect what your applications' data models look like. They are also used to listen to events and react accordingly. This tutorial will not be addressing how to bind models and collections to views but will focus on view functionality and how to use views with a JavaScript templating library, specifically [Underscore.js's _.template](http://underscorejs.org/#template).
 
 We will be using [jQuery 1.8.2](http://jquery.com/) as our DOM manipulator. It's possible to use other libraries such as [MooTools](http://mootools.net/) or [Sizzle](http://sizzlejs.com/), but official Backbone.js documentation endorses jQuery. Backbone.View events may not work with libraries other than jQuery.
 
@@ -49,7 +49,7 @@ _Note: Keep in mind that this binds the container element. Any events we trigger
 
 ## Loading a template
 
-Backbone.js is dependent on Underscore.js, which includes its own micro-templating solution. Refer to [Underscore.js's documentation](http://documentcloud.github.com/underscore/) for more information.
+Backbone.js is dependent on Underscore.js, which includes its own micro-templating solution. Refer to [Underscore.js's documentation](http://underscorejs.org/) for more information.
 
 Let us implement a "render()" function and call it when the view is initialized. The "render()" function will load our template into the view's "el" property using jQuery.
 


### PR DESCRIPTION
"http://documentcloud.github.io/underscore" is only updated through version 1.5.0, while "underscorejs.org" is current through 1.7.0. 

"underscorejs.org" is also the official homepage for the project, and is easier to remember if people want to reference again later. 

I've double checked both links and they behave exactly as the existing links do. The link pointing directly to #template still points directly to #template within the underscore documentation.

![image](https://cloud.githubusercontent.com/assets/7017045/5586355/2bd47c82-9080-11e4-89de-ff7a52ee5cc4.png)
