### PR TITLE
Pointed to backbonejs.org/#Router for documentation

### DIFF
--- a/_posts/2011-01-27-what-is-a-router.md
+++ b/_posts/2011-01-27-what-is-a-router.md
@@ -116,7 +116,7 @@ Routes are quite powerful and in an ideal world your application should never co
 Remember to do a pull request for any errors you come across.
 
 ### Relevant Links
-* [Backbone.js official router documentation](http://documentcloud.github.com/backbone/#Router)
+* [Backbone.js official router documentation](http://backbonejs.org/#Router)
 * [Using routes and understanding the hash tag](http://thomasdavis.github.com/2011/02/07/making-a-restful-ajax-app.html)
 
 ### Contributors


### PR DESCRIPTION
Previous link pointed to documentcloud, which was only updated through v1.0.0. Tested to make sure it still points directly to Router. 

![image](https://cloud.githubusercontent.com/assets/7017045/5593536/10e5d30e-91c9-11e4-94fe-6496fc10a584.png)
