### PR TITLE
Updated Getting Started Link away from Free Trial

### DIFF
--- a/_posts/2013-8-29-real-time-backbone-with-pubnub.md
+++ b/_posts/2013-8-29-real-time-backbone-with-pubnub.md
@@ -24,7 +24,7 @@ The easiest way to get started is by using bower via `bower install pubnub-backb
 <script src="/path/to/backbone-pubnub.min.js"></script>
 {% endhighlight %}
 
-The easiest way to get started using the library is by creating a PubNub based collection. This will automatically propagate all create, update, and delete methods across all other clients in real-time. This requires creating a free account to get your API keys at [http://pubnub.com/free-trial](http://pubnub.com/free-trial) and then initializing a global PubNub instance:
+The easiest way to get started using the library is by creating a PubNub based collection. This will automatically propagate all create, update, and delete methods across all other clients in real-time. This requires creating a free account to get your API keys at [http://www.pubnub.com/get-started](http://www.pubnub.com/get-started) and then initializing a global PubNub instance:
 
 {% highlight javascript %}
 var pubnub = PUBNUB.init({


### PR DESCRIPTION
Link to "Free Trial" now leads directly to "Getting Started" page, so I updated the link and text to point there directly to avoid confusing people.

![image](https://cloud.githubusercontent.com/assets/7017045/5593565/6fe7134e-91ca-11e4-8550-803001226167.png)
