### PR TITLE
Updated URL structure for bocoup in Relevant Links

### DIFF
--- a/_posts/2011-10-10-organizing-backbone-using-modules.md
+++ b/_posts/2011-10-10-organizing-backbone-using-modules.md
@@ -379,7 +379,7 @@ Get in touch with me on twitter, comments or GitHub!
 
 ### Relevant Links
 
-* [Organizing Your Backbone.js Application With Modules](http://weblog.bocoup.com/organizing-your-backbone-js-application-with-modules)
+* [Organizing Your Backbone.js Application With Modules](http://bocoup.com/weblog/organizing-your-backbone-js-application-with-modules/)
 
 ### Contributors
 


### PR DESCRIPTION
He changed from weblog.bocoup.com to bocoup.com/weblog. I double checked and the link still works with either URL, but this change should help maintain future compatibility. 

![image](https://cloud.githubusercontent.com/assets/7017045/5593572/7c863bce-91cb-11e4-8fdd-b5fffd3efa5f.png)
