### PR TITLE
Removed * in "*splat" to prevent unexpected italics

### DIFF
--- a/_posts/2011-01-27-what-is-a-router.md
+++ b/_posts/2011-01-27-what-is-a-router.md
@@ -78,7 +78,7 @@ _Notice the change in the url_
 
 ## Dynamic Routing Cont. ":params" and "*splats"
 
-Backbone uses two styles of variables when implementing routes.   First there are ":params" which match any URL components between slashes.  Then there are "*splats" which match any number of URL components.   Note that due to the nature of a "*splat" it will always be the last variable in your URL as it will match any and all components.
+Backbone uses two styles of variables when implementing routes.   First there are ":params" which match any URL components between slashes.  Then there are "*splats" which match any number of URL components.   Note that due to the nature of a splat it will always be the last variable in your URL as it will match any and all components.
 
 Any "*splats" or ":params" in route definitions are passed as arguments (in respective order) to the associated function.  A route defined as "/:route/:action" will pass 2 variables (“route” and “action”) to the callback function.     (If this is confusing please post a comment and I will try articulate it better)
 


### PR DESCRIPTION
Having two "_" in one paragraph caused the text in between the stars to be italicized. I changed the second instance from "_splat" to just splat to prevent this.

Existing rendering with unexpected italicizing: 
![image](https://cloud.githubusercontent.com/assets/7017045/5593608/541890ca-91cf-11e4-832c-d4713a6d237e.png)

Change deleting both quotes and the star in the second instance of splat: 
![image](https://cloud.githubusercontent.com/assets/7017045/5593609/6cecece0-91cf-11e4-9ab5-69b0ee5107a1.png)
