### PR TITLE
Add commas to increase readability

### DIFF
--- a/_site/what-is-a-model/index.html
+++ b/_site/what-is-a-model/index.html
@@ -194,7 +194,7 @@
     <span class="kd">var</span> <span class="nx">person</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Person</span><span class="p">({</span> <span class="nx">name</span><span class="o">:</span> <span class="s2">&quot;Thomas&quot;</span><span class="p">,</span> <span class="nx">age</span><span class="o">:</span> <span class="mi">67</span><span class="p">});</span>
     <span class="nx">person</span><span class="p">.</span><span class="nx">set</span><span class="p">({</span><span class="nx">name</span><span class="o">:</span> <span class="s1">&#39;Stewie Griffin&#39;</span><span class="p">});</span> <span class="c1">// This triggers a change and will alert()</span></code></pre></div>
 
-<p>So we can bind the change listener to individual attributes or if we like simply &#39;<em>this.on(&quot;change&quot;, function(model){});</em>&#39; to listen for changes to all attributes of the model.</p>
+<p>So we can bind the change listener to individual attributes, or, if we like, simply &#39;<em>this.on(&quot;change&quot;, function(model){});</em>&#39; to listen for changes to all attributes of the model.</p>
 
 <h2>Interacting with the server</h2>
 


### PR DESCRIPTION
Clarified line 197 by adding a few commas to provide natural pauses to increase readability. I am new to Backbone and think this is a great resource. I changed:

So we can bind the change listener to individual attributes or if we like simply 'this.on("change", function(model){});' to listen for changes to all attributes of the model.

to 

So we can bind the change listener to individual attributes, or, if we like, simply 'this.on("change", function(model){});' to listen for changes to all attributes of the model.
